### PR TITLE
Run TSan tests with ASLR disabled and improve FD operation safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 *.exe
 *.out
 *.app
+*.log
 /build
 /vcpkg_installed
 ghz-web

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ test-tsan: clean
 	@echo "Building with TSan enabled..."
 	@cmake -B $(BUILD_DIR) -S . $(CMAKE_FLAGS) -DENABLE_TSAN=ON
 	@cmake --build $(BUILD_DIR) -j $(shell nproc)
-	@echo "Running tests with TSan..."
-	@ctest --test-dir $(BUILD_DIR) --output-on-failure
+	@echo "Running tests with TSan (ASLR disabled)..."
+	@setarch $$(uname -m) -R ctest --test-dir $(BUILD_DIR) --output-on-failure
 
 # ===========================================================================
 # Benchmarks (CLI & In-process)

--- a/src/event/dispatcher_impl.cpp
+++ b/src/event/dispatcher_impl.cpp
@@ -185,6 +185,13 @@ public:
   }
 
   void addFd(int fd, uint32_t events, FdCb cb) override {
+    if (!isThreadSafe()) {
+      post([this, fd, events, cb = std::move(cb)]() mutable {
+        addFd(fd, events, std::move(cb));
+      });
+      return;
+    }
+
     struct epoll_event ev{};
     ev.events = events;
     ev.data.fd = fd;
@@ -202,6 +209,13 @@ public:
   }
 
   void modifyFd(int fd, uint32_t events) override {
+    if (!isThreadSafe()) {
+      post([this, fd, events]() {
+        modifyFd(fd, events);
+      });
+      return;
+    }
+
     struct epoll_event ev{};
     ev.events = events;
     ev.data.fd = fd;
@@ -212,6 +226,13 @@ public:
   }
 
   void removeFd(int fd) override {
+    if (!isThreadSafe()) {
+      post([this, fd]() {
+        removeFd(fd);
+      });
+      return;
+    }
+
     // Tell OS to stop monitoring immediately
     epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, nullptr);
 

--- a/src/server/uds_admin_handler.cpp
+++ b/src/server/uds_admin_handler.cpp
@@ -75,12 +75,14 @@ void UdsAdminHandler::stop() {
     if (server_fd_ >= 0) {
         ::shutdown(server_fd_, SHUT_RDWR); // Kick accept() out
         ::close(server_fd_);
-        server_fd_ = -1;
+        // Do not set server_fd_ = -1 here, acceptLoop might still be reading it.
     }
 
     if (accept_thread_.joinable()) {
         accept_thread_.join();
     }
+
+    server_fd_ = -1;
 
     ::unlink(socket_path_.c_str());
     info("[UDS Admin] Stopped.");


### PR DESCRIPTION
Trong file `src/server/uds_admin_handler.cpp`, hàm `stop()` của chúng ta có đoạn code sau:
```cpp
    if (server_fd_ >= 0) {
        ::shutdown(server_fd_, SHUT_RDWR);
        ::close(server_fd_);
        server_fd_ = -1; // <---  ĐÂY!
    }
```
Khi Main Thread gọi `stop()`, nó đóng socket và gán thẳng `server_fd_ = -1`. 
Cùng một phần nghìn giây đó, cái luồng chạy ngầm (`acceptLoop`) đang nằm ở vòng lặp `::accept(server_fd_, ...)` và cố gắng đọc cái biến `server_fd_` này. 
Một thằng Ghi (`-1`), một thằng Đọc (lấy FD) trên cùng một biến `int` mà không có Mutex thì **Data Race!**

---

#  `SEGFAULT` (WorkerTest, KallistoCoreTest, UdsAdminTest)

**Phân tích nguyên nhân:**
- Khi gọi `worker.bindListener(...)` từ Main Thread của bài test, dòng lệnh này chạy thẳng vào hàm `DispatcherImpl::addFd()`.
- Hàm `addFd()` này đi ghi (thêm key-value mới) vào biến `std::unordered_map<int, FdCb> fd_callbacks_`.
- CÙNG LÚC ĐÓ, luồng Epoll (đã được worker khởi động ngầm từ trước) đang liên tục lặp qua chính cái `unordered_map` này trong hàm `dispatchFiredEvents()`.
- **Kết quả:** Đọc và Ghi đồng thời trên một `unordered_map` không có Mutex bảo vệ -> **Data Race**. Cấu trúc của Map bị phá nát (corruption), và chương trình dính `SEGFAULT`.

Trong kiến trúc Event Loop chuẩn (như Envoy hay Libuv), không có ai được phép chạm vào cấu trúc dữ liệu của Dispatcher nếu không đứng trên thread của chính nó:

Logic mới:
```cpp
  void addFd(int fd, uint32_t events, FdCb cb) override {
    if (!isThreadSafe()) { // Nếu bị gọi chéo từ luồng khác (Main Thread)
      post([this, fd, events, cb = std::move(cb)]() mutable {
        addFd(fd, events, std::move(cb)); // Gói lại và ném vào hàng đợi (Queue)
      });
      return;
    }
    // ... thực hiện update map an toàn
```

Giờ đây, nếu luồng Main muốn thêm socket, nó sẽ tự động `post()` hành động đó vào Event Loop. Epoll worker sẽ nhặt hành động này ra xử lý tuần tự (Single-thread R/W), **triệt tiêu hoàn toàn Data Race mà không cần dùng đến Mutex đắt đỏ**.